### PR TITLE
Bug 1508278 - Use include_tasks instead of include

### DIFF
--- a/roles/rhscl-postgresql-apb-openshift/tasks/main.yml
+++ b/roles/rhscl-postgresql-apb-openshift/tasks/main.yml
@@ -27,10 +27,10 @@
       service: postgresql
   when: state == 'absent'
 
-- include: dev.yml
+- include_tasks: dev.yml
   when: _apb_plan_id == "dev"
 
-- include: prod.yml
+- include_tasks: prod.yml
   when: _apb_plan_id == "prod"
 
 - name: delete replication controller


### PR DESCRIPTION
include is deprecated and throws a warning.